### PR TITLE
Add instructions for partial clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,22 @@ Interested in contributing to this project? See the [board](https://github.com/o
 
 To add a new set of artifacts for your project, simply add your NPM package to the [`packages`](https://github.com/privacy-scaling-explorations/snark-artifacts/tree/main/packages) folder. The packages are published on NPM and made available on your preferred CDN (e.g. https://unpkg.com).
 
+### Partial clone
+
+For a more manageable clone that includes only the packages relevant to you or none of them, you can use git's [`sparse-checkout`](https://git-scm.com/docs/git-sparse-checkout) and [`--filter`](https://git-scm.com/docs/git-rev-list#Documentation/git-rev-list.txt---filterltfilter-specgt) features. This will reduce clone time and improve git performance.
+
+```bash
+git clone --sparse --filter=blob:none <forkedUrl>
+```
+
+And finally, if you need a specific package:
+
+```bash
+git sparse-checkout add packages/<package>
+```
+
+### Downloading artifacts
+
 ZK-Kit provides a set of functions to automatically download your artifacts. For example:
 
 ```ts


### PR DESCRIPTION
This PR adds the instructions to partially clone the repo without downloading all packages. Devs can selectively download some or none of them.