### PR TITLE
chore: move `latest` tag upon releasing new versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,9 +31,13 @@ jobs:
         run: npm i
 
       - name: Release
+        id: changesets
         uses: changesets/action@v1
         with:
           publish: npm exec changeset publish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Update 'latest' tag for published packages
+        run: ./scripts/bin/move-latest-tag ${{ steps.changesets.outputs.publishedPackages }} ${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,4 +40,5 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Update 'latest' tag for published packages
+        # https://github.com/changesets/action?tab=readme-ov-file#outputs
         run: ./scripts/bin/move-latest-tag ${{ steps.changesets.outputs.publishedPackages }} ${{ github.sha }}

--- a/scripts/bin/move-latest-tag
+++ b/scripts/bin/move-latest-tag
@@ -3,19 +3,19 @@
 set -euo pipefail
 
 move_tag() {
-    local package="$1"
-    local commit_sha="$2"
-    local tag="$package@latest"
+  local package="$1"
+  local commit_sha="$2"
+  local tag="$package@latest"
 
-    git tag -d "$tag"
-    git push origin ":refs/tags/$tag"
+  git tag -d "$tag"
+  git push origin ":refs/tags/$tag"
 
-    git tag "$tag" "$commit_sha"
-    git push origin "$tag"
+  git tag "$tag" "$commit_sha"
+  git push origin "$tag"
 }
 
 get_package_names() {
-    jq -r '.[].name' "$1"
+  jq -r '.[].name' "$1"
 }
 
 main() {

--- a/scripts/bin/move-latest-tag
+++ b/scripts/bin/move-latest-tag
@@ -7,9 +7,7 @@ move_tag() {
   local commit_sha="$2"
   local tag="$package@latest"
 
-  git tag -d "$tag"
-  git push origin ":refs/tags/$tag"
-
+  git push -d origin "$tag"
   git tag "$tag" "$commit_sha"
   git push origin "$tag"
 }

--- a/scripts/bin/move-latest-tag
+++ b/scripts/bin/move-latest-tag
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -euo pipefail
+
+move_tag() {
+    local package="$1"
+    local commit_sha="$2"
+    local tag="$package@latest"
+
+    git tag -d "$tag"
+    git push origin ":refs/tags/$tag"
+
+    git tag "$tag" "$commit_sha"
+    git push origin "$tag"
+}
+
+get_package_names() {
+    jq -r '.[].name' "$1"
+}
+
+main() {
+  local published_packages="$1"
+  local commit_sha="$2"
+
+  while IFS= read -r package; do
+    move_tag "$package" "$commit_sha"
+  done < <(get_package_names "$published_packages")
+}
+
+main "$@"


### PR DESCRIPTION
Towards https://github.com/privacy-scaling-explorations/zk-kit/pull/273
In https://github.com/privacy-scaling-explorations/zk-kit/pull/273, we want to fallback to github to fetch the artifacts.  
Although github provides urls for the packages version tag, to my knowledge it does not know what the default `latest` tag version is.

So this PR includes an additional step in the release workflow to "move" the `latest` version tag (I have manually created it this time) for the packages that are being released.

This way in `@zk-kit/utils` we will be able to use the following urls:
`proof = "eddsa`, `version? = "latest"`, `artifact = "wasm"`

- `https://unpkg.com/@zk-kit/{proof}-artifacts@latest/{proof}.{artifact}`
- `https://cdn.jsdelivr.net/npm/@zk-kit/{proof}-artifacts@latest/{proof}.{artifact}`
- `https://github.com/privacy-scaling-explorations/snark-artifacts/raw/@zk-kit/{proof}-artifacts@latest/packages/{proof}/{proof}.{artifact}`


We could even consider changing the repository directory strcuture:
`./packages/eddsa -> ./eddsa-artifacts` to have the github raw url completely match what unpkg and jsdelivr use


**Note**
Script integration in release workflow tricky to test so it is untested :speak_no_evil: (if buggy, it can't do any damage except pushing a `latest` tag for a wrong pkg name at a wrong sha, I would fix/debug it manually if I did a mistake) 
