### PR TITLE
Upload artifacts to S3 bucket

### DIFF
--- a/.github/scripts/upload-artifacts.sh
+++ b/.github/scripts/upload-artifacts.sh
@@ -8,7 +8,8 @@ cd packages
 git restore-mtime
 
 for artifact in $artifacts; do
-  aws s3 sync $artifact s3://$s3_bucket/$artifact --delete
+  package_version=$(jq -r '.version' "$artifact/package.json")
+  aws s3 sync $artifact s3://$s3_bucket/$artifact/$package_version --delete
 done
 
 exit 0

--- a/.github/scripts/upload-artifacts.sh
+++ b/.github/scripts/upload-artifacts.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -ex
+
+s3_bucket="snark-artifacts"
+artifacts=$(ls packages/ | grep -v 'artifacts\|cli')
+
+cd packages
+git restore-mtime
+
+for artifact in $artifacts; do
+  aws s3 sync $artifact s3://$s3_bucket/$artifact --delete
+done
+
+exit 0

--- a/.github/workflows/upload-artifacts.yaml
+++ b/.github/workflows/upload-artifacts.yaml
@@ -1,0 +1,40 @@
+name: Upload Artifacts
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'packages/**'
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  upload-artifacts:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: arn:aws:iam::490752553772:role/snark-artifacts-assume_role-slc
+          role-duration-seconds: 900
+          aws-region: us-west-2
+
+      - name: Install package
+        run: |
+          sudo apt install git-restore-mtime
+
+      - name: Upload artifacts to S3 bucket
+        run: |
+          .github/scripts/upload-artifacts.sh

--- a/.github/workflows/upload-artifacts.yaml
+++ b/.github/workflows/upload-artifacts.yaml
@@ -5,6 +5,8 @@ on:
       - main
     paths:
       - 'packages/**'
+      - '!packages/artifacts/**'
+      - '!packages/cli/**'
 
 concurrency:
   group: ${{ github.workflow }}

--- a/.github/workflows/upload-artifacts.yaml
+++ b/.github/workflows/upload-artifacts.yaml
@@ -18,6 +18,15 @@ jobs:
       contents: read
 
     steps:
+      - name: Wait for Release to succeed
+        if: github.event_name == 'push'
+        uses: lewagon/wait-on-check-action@v1.3.4
+        with:
+          ref: ${{ github.ref }}
+          check-name: 'release'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 30
+
       - name: Checkout
         uses: actions/checkout@v4
         with:


### PR DESCRIPTION
**Description**

With this PR a new workflow is introduced that uploads and updates the artifacts to an S3 bucket.
Additionally, a CloudFront distribution for this specific bucket was created to accelerate content delivery.
The distribution domain name is **snark-artifacts.pse.dev**, and files can be downloaded using the following structure:
https://snark-artifacts.pse.dev/poseidon/poseidon-1.wasm
https://snark-artifacts.pse.dev/semaphore-identity/semaphore-identity.wasm

**Issue**

Re #89