### PR TITLE
chore: include pse cdn in benchmark

### DIFF
--- a/scripts/bin/benchmark.bash
+++ b/scripts/bin/benchmark.bash
@@ -48,9 +48,9 @@ main() {
     "https://snark-artifacts.pse.dev/poseidon/latest" \
     "https://cdn.jsdelivr.net/npm/@zk-kit/poseidon-artifacts@latest" \
     "https://unpkg.com/@zk-kit/poseidon-artifacts@latest" \
-    "https://github.com/privacy-scaling-explorations/snark-artifacts/raw/@zk-kit/poseidon-artifacts@1.0.0-beta.1/packages/poseidon"; do
+    "https://github.com/privacy-scaling-explorations/snark-artifacts/raw/@zk-kit/poseidon-artifacts@latest/packages/poseidon"; do
     for _ in {1..10}; do # compute average over 10 runs
-      dl_all "$cdn" | tee -a "$log" & # download from all CDNs in parallel
+      dl_all "$cdn" | tee -a "$log" & # execute all runs in parallel
     done
   done
 

--- a/scripts/bin/benchmark.bash
+++ b/scripts/bin/benchmark.bash
@@ -4,7 +4,7 @@ dl() {
   local cdn="$1"
   local artifact="$2"
   local url="$cdn/$artifact"
-  curl -s -o /dev/null "$url"
+  curl -s -L -o /dev/null "$url"
 }
 
 dl_all() {

--- a/scripts/bin/benchmark.bash
+++ b/scripts/bin/benchmark.bash
@@ -31,10 +31,10 @@ average() {
 /pse/ { pse_sum += $2; pse_count += 1 }
 END {
   print "download time average (s)"
-  print "  unpkg", unpkg_sum/unpkg_count
+  print "  unpkg   ", unpkg_sum/unpkg_count
   print "  jsdelivr", jsdelivr_sum/jsdelivr_count
-  print "  github", github_sum/github_count
-  print "  pse", pse_sum/pse_count
+  print "  github  ", github_sum/github_count
+  print "  pse     ", pse_sum/pse_count
 }
 ' "$log"
 }

--- a/scripts/bin/benchmark.bash
+++ b/scripts/bin/benchmark.bash
@@ -3,27 +3,22 @@
 dl() {
   local cdn="$1"
   local artifact="$2"
-  local version=${cdn/*github.com*/1.0.0}
-  version=${version//*/latest}
-
   local url="$cdn/$artifact"
   curl -s -o /dev/null "$url"
 }
 
 dl_all() {
   local cdn="$1"
-  # poseidon is the package that has the most artifacts
-  # so using it for testing
-  # deliberately download sequentially as this is what is taking so long
-  # and causing issues in zk-kit ci atm
+
   start=$(date +%s)
   for artifact in poseidon-{1..16}.{wasm,zkey}; do
-    dl "$cdn" "$artifact"
+    dl "$cdn" "$artifact" # download deliberately sequentially to avoid throttling happening with public CDNs
   done
   end=$(date +%s)
   cdn=${cdn/*github.com*/github}
   cdn=${cdn/*unpkg.com*/unpkg}
   cdn=${cdn/*jsdelivr.net*/jsdelivr}
+  cdn=${cdn/*snark-artifacts.pse.dev*/pse}
   echo "$cdn,$((end - start))"
 }
 
@@ -33,11 +28,13 @@ average() {
 /unpkg/ { unpkg_sum += $2; unpkg_count += 1 }
 /jsdelivr/ { jsdelivr_sum += $2; jsdelivr_count += 1 }
 /github/ { github_sum += $2; github_count += 1 }
+/pse/ { pse_sum += $2; pse_count += 1 }
 END {
   print "download time average (s)"
   print "  unpkg", unpkg_sum/unpkg_count
   print "  jsdelivr", jsdelivr_sum/jsdelivr_count
   print "  github", github_sum/github_count
+  print "  pse", pse_sum/pse_count
 }
 ' "$log"
 }
@@ -46,11 +43,14 @@ main() {
   local log
   log=$(mktemp)
 
-  for cdn in "https://cdn.jsdelivr.net/npm/@zk-kit/poseidon-artifacts@latest" \
+  # using arbitrarily poseidon artifacts for benchmarking
+  for cdn in \
+    "https://snark-artifacts.pse.dev/poseidon/latest" \
+    "https://cdn.jsdelivr.net/npm/@zk-kit/poseidon-artifacts@latest" \
     "https://unpkg.com/@zk-kit/poseidon-artifacts@latest" \
-    "https://github.com/privacy-scaling-explorations/snark-artifacts/raw/@zk-kit/semaphore-artifacts@1.0.0/packages/poseidon"; do
-    for _ in {1..10}; do
-      dl_all "$cdn" | tee -a "$log" &
+    "https://github.com/privacy-scaling-explorations/snark-artifacts/raw/@zk-kit/poseidon-artifacts@1.0.0-beta.1/packages/poseidon"; do
+    for _ in {1..10}; do # compute average over 10 runs
+      dl_all "$cdn" | tee -a "$log" & # download from all CDNs in parallel
     done
   done
 


### PR DESCRIPTION
run benchmark with `./scripts/bin/benchmark.bash`

My results, done with a rather bad connection (10 Mbps, VPN on, location eu/west):

```txt
download time average (s)
  unpkg    136
  jsdelivr 328.8
  github   142.7
  pse      406.4
```

another run:
```txt
download time average (s)
  unpkg    168.8
  jsdelivr 417.9
  github   166.6
  pse      449.9
```