### PR TITLE
feat(artifacts): download artifacts from pse CDN

### DIFF
--- a/.changeset/great-eggs-unite.md
+++ b/.changeset/great-eggs-unite.md
@@ -1,0 +1,5 @@
+---
+"@zk-kit/artifacts": minor
+---
+
+download artifacts from https://snark-artifacts.pse.dev

--- a/packages/artifacts/src/download/download.ts
+++ b/packages/artifacts/src/download/download.ts
@@ -3,16 +3,8 @@ import { mkdir } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import type { Urls } from './urls.ts'
 
-async function fetchRetry(urls: string[]): Promise<ReturnType<typeof fetch>> {
-  const [url] = urls
-  if (!url) throw new Error('No urls to try')
-  return fetch(url).catch(() => fetchRetry(urls.slice(1)))
-}
-
-export async function download(urls: Urls | string[] | string, outputPath: string) {
-  const { body, ok, statusText, url } = Array.isArray(urls)
-    ? await fetchRetry(urls as string[])
-    : await fetch(urls as string)
+export async function download(url: string, outputPath: string) {
+  const { body, ok, statusText } = await fetch(url)
   if (!ok)
     throw new Error(`Failed to fetch ${url}: ${statusText}`)
   if (!body) throw new Error('Failed to get response body')
@@ -42,7 +34,7 @@ export async function download(urls: Urls | string[] | string, outputPath: strin
   }
 }
 
-export async function maybeDownload(urls: Urls | string[] | string, outputPath: string) {
-  if (!existsSync(outputPath)) await download(urls, outputPath)
+export async function maybeDownload(url: string, outputPath: string) {
+  if (!existsSync(outputPath)) await download(url, outputPath)
   return outputPath
 }

--- a/packages/artifacts/src/download/download.ts
+++ b/packages/artifacts/src/download/download.ts
@@ -1,7 +1,6 @@
 import { createWriteStream, existsSync } from 'node:fs'
 import { mkdir } from 'node:fs/promises'
 import { dirname } from 'node:path'
-import type { Urls } from './urls.ts'
 
 export async function download(url: string, outputPath: string) {
   const { body, ok, statusText } = await fetch(url)

--- a/packages/artifacts/src/download/index.browser.ts
+++ b/packages/artifacts/src/download/index.browser.ts
@@ -1,15 +1,28 @@
-import type { SnarkArtifacts } from './types'
-import { getSnarkArtifactUrls } from './urls'
+import { type Project, projects } from '../projects'
+import type { SnarkArtifacts, Version } from './types'
+import { getBaseUrl } from './urls'
 
 // TODO: retry for browser?
-// beisdes, is caching already handled by circom/snarkjs?
+// besides, is caching already handled by circom/snarkjs?
 export default async function maybeGetSnarkArtifacts(
-  ...pars: Parameters<typeof getSnarkArtifactUrls>
+  project: Project,
+  options: {
+    parameters?: (bigint | number | string)[]
+    version?: Version
+    cdnUrl?: string
+  } = {},
 ): Promise<SnarkArtifacts> {
-  const { wasms, zkeys } = await getSnarkArtifactUrls(...pars)
+  if (!projects.includes(project))
+    throw new Error(`Project '${project}' is not supported`)
+
+  options.version ??= 'latest'
+  const url = await getBaseUrl(project, options.version)
+  const parameters = options.parameters
+    ? `-${options.parameters.join('-')}`
+    : ''
 
   return {
-    wasm: wasms[0],
-    zkey: zkeys[0],
+    wasm: `${url}${parameters}.wasm`,
+    zkey: `${url}${parameters}.zkey`,
   }
 }

--- a/packages/artifacts/src/download/index.browser.ts
+++ b/packages/artifacts/src/download/index.browser.ts
@@ -2,8 +2,6 @@ import { type Project, projects } from '../projects'
 import type { SnarkArtifacts, Version } from './types'
 import { getBaseUrl } from './urls'
 
-// TODO: retry for browser?
-// besides, is caching already handled by circom/snarkjs?
 export default async function maybeGetSnarkArtifacts(
   project: Project,
   options: {

--- a/packages/artifacts/src/download/index.node.ts
+++ b/packages/artifacts/src/download/index.node.ts
@@ -1,7 +1,7 @@
 import { tmpdir } from 'node:os'
 import { maybeDownload } from './download.ts'
-import type { SnarkArtifacts } from './types'
 import _maybeGetSnarkArtifacts from './index.browser.ts'
+import type { SnarkArtifacts } from './types'
 
 const extractEndPath = (url: string) => url.split('pse.dev/')[1]
 
@@ -19,7 +19,7 @@ const extractEndPath = (url: string) => url.split('pse.dev/')[1]
 export default async function maybeGetSnarkArtifacts(
   ...pars: Parameters<typeof _maybeGetSnarkArtifacts>
 ): Promise<SnarkArtifacts> {
-  const urls = await maybeGetSnarkArtifacts(
+  const urls = await _maybeGetSnarkArtifacts(
     ...pars,
   )
 

--- a/packages/artifacts/src/download/index.node.ts
+++ b/packages/artifacts/src/download/index.node.ts
@@ -1,10 +1,9 @@
 import { tmpdir } from 'node:os'
 import { maybeDownload } from './download.ts'
 import type { SnarkArtifacts } from './types'
-import { getSnarkArtifactUrls } from './urls'
+import _maybeGetSnarkArtifacts from './index.browser.ts'
 
-// https://unpkg.com/@zk-kit/poseidon-artifacts@latest/poseidon.wasm -> @zk/poseidon-artifacts@latest/poseidon.wasm
-const extractEndPath = (url: string) => url.substring(url.indexOf('@zk'))
+const extractEndPath = (url: string) => url.split('pse.dev/')[1]
 
 /**
  * Downloads SNARK artifacts (`wasm` and `zkey`) files if not already present in OS tmp folder.
@@ -18,17 +17,17 @@ const extractEndPath = (url: string) => url.substring(url.indexOf('@zk'))
  * @returns {@link SnarkArtifacts}
  */
 export default async function maybeGetSnarkArtifacts(
-  ...pars: Parameters<typeof getSnarkArtifactUrls>
+  ...pars: Parameters<typeof _maybeGetSnarkArtifacts>
 ): Promise<SnarkArtifacts> {
-  const { wasms, zkeys } = await getSnarkArtifactUrls(
+  const urls = await maybeGetSnarkArtifacts(
     ...pars,
   )
 
-  const outputPath = `${tmpdir()}/${extractEndPath(wasms[0])}`
+  const outputPath = `${tmpdir()}/snark-artifacts/${extractEndPath(urls.wasm)}`
 
   const [wasm, zkey] = await Promise.all([
-    maybeDownload(wasms, outputPath),
-    maybeDownload(zkeys, outputPath.replace(/.wasm$/, '.zkey')),
+    maybeDownload(urls.wasm, outputPath),
+    maybeDownload(urls.zkey, outputPath.replace(/.wasm$/, '.zkey')),
   ])
 
   return {

--- a/packages/artifacts/src/download/types.ts
+++ b/packages/artifacts/src/download/types.ts
@@ -5,10 +5,6 @@
  */
 export type SnarkArtifacts = Record<'wasm' | 'zkey', string>
 
-// Recursively build an array type of length L with elements of type T.
-export type ArrayOf<T, L extends number, A extends unknown[] = []> = A['length'] extends L ? A
-  : ArrayOf<T, L, [T, ...A]>
-
 type Digit = `${number}`
 type PreRelease = 'alpha' | 'beta'
 

--- a/packages/artifacts/src/download/urls.ts
+++ b/packages/artifacts/src/download/urls.ts
@@ -1,7 +1,7 @@
-import { type Project, projects } from '../projects'
-import type { ArrayOf, Version } from './types'
+import { type Project } from '../projects'
+import type { Version } from './types'
 
-export type Urls = ArrayOf<string, 3>
+const BASE_URL = 'https://snark-artifacts.pse.dev'
 
 export async function getAvailableVersions(project: Project) {
   const res = await fetch(`https://registry.npmjs.org/@zk-kit/${project}-artifacts`)
@@ -15,35 +15,7 @@ async function isVersionAvailableOrThrow(project: Project, version: Version) {
     throw new Error(`Version '${version}' is not available for project '${project}'`)
 }
 
-export async function getBaseUrls(project: Project, version: Version): Promise<Urls> {
+export async function getBaseUrl(project: Project, version: Version): Promise<string> {
   await isVersionAvailableOrThrow(project, version)
-  return [
-    `https://unpkg.com/@zk-kit/${project}-artifacts@${version}/${project}`,
-    `https://raw.githubusercontent.com/privacy-scaling-explorations/snark-artifacts/@zk-kit/${project}-artifacts@${version}/packages/${project}/${project}`,
-    `https://cdn.jsdelivr.net/npm/@zk-kit/${project}-artifacts@${version}/${project}`,
-  ]
-}
-
-export async function getSnarkArtifactUrls(
-  project: Project,
-  options: {
-    parameters?: (bigint | number | string)[]
-    version?: Version
-    cdnUrl?: string
-  } = {},
-) {
-  if (!projects.includes(project))
-    throw new Error(`Project '${project}' is not supported`)
-
-  options.version ??= 'latest'
-  const urls = await getBaseUrls(project, options.version)
-
-  const parameters = options.parameters
-    ? `-${options.parameters.join('-')}`
-    : ''
-
-  return {
-    wasms: urls.map((url) => `${url}${parameters}.wasm`) as unknown as Urls,
-    zkeys: urls.map(url => `${url}${parameters}.zkey`) as unknown as Urls,
-  }
+  return `${BASE_URL}/${project}/${version}`
 }

--- a/packages/artifacts/src/download/urls.ts
+++ b/packages/artifacts/src/download/urls.ts
@@ -1,4 +1,4 @@
-import { type Project } from '../projects'
+import type { Project } from '../projects'
 import type { Version } from './types'
 
 const BASE_URL = 'https://snark-artifacts.pse.dev'

--- a/packages/artifacts/src/download/urls.ts
+++ b/packages/artifacts/src/download/urls.ts
@@ -17,5 +17,5 @@ async function isVersionAvailableOrThrow(project: Project, version: Version) {
 
 export async function getBaseUrl(project: Project, version: Version): Promise<string> {
   await isVersionAvailableOrThrow(project, version)
-  return `${BASE_URL}/${project}/${version}`
+  return `${BASE_URL}/${project}/${version}/${project}`
 }

--- a/packages/artifacts/test/download.test.ts
+++ b/packages/artifacts/test/download.test.ts
@@ -1,203 +1,220 @@
-import fs from 'node:fs'
-import fsPromises from 'node:fs/promises'
-import maybeGetSnarkArtifactsBrowser from '../src/download/index.browser'
-import maybeGetSnarkArtifacts from '../src/download/index.node'
-import { getAvailableVersions, getSnarkArtifactUrls } from '../src/download/urls'
-import { Project } from '../src/projects'
+import fs from "node:fs";
+import fsPromises from "node:fs/promises";
+import maybeGetSnarkArtifactsBrowser from "../src/download/index.browser";
+import maybeGetSnarkArtifacts from "../src/download/index.node";
+import { getAvailableVersions } from "../src/download/urls";
+import { Project } from "../src/projects";
 
-const version = '1.0.0'
+const version = "1.0.0-beta.1";
 
-describe('getAvailableVersions', () => {
-  it('Should return available versions', async () => {
-    const versions = await getAvailableVersions(Project.POSEIDON)
+describe("getAvailableVersions", () => {
+  it("Should return available versions", async () => {
+    const versions = await getAvailableVersions(Project.POSEIDON);
 
-    expect(versions).toContain(version)
-  }, 20_000)
-})
+    expect(versions).toContain(version);
+  }, 20_000);
+});
 
-describe('getSnarkArtifactUrls', () => {
-  it('Should return valid urls', async () => {
-    const { wasms, zkeys } = await getSnarkArtifactUrls(Project.POSEIDON, {
-      parameters: ['2'],
-      version,
-    })
+describe("maybeGetSnarkArtifacts", () => {
+  describe("browser", () => {
+    it("Should return valid urls", async () => {
+      const { wasm, zkey } = await maybeGetSnarkArtifactsBrowser(
+        Project.POSEIDON,
+        {
+          parameters: ["2"],
+          version,
+        }
+      );
 
-    for (const url of wasms)
-      await expect(fetch(url)).resolves.toHaveProperty('ok', true)
-    for (const url of zkeys)
-      await expect(fetch(url)).resolves.toHaveProperty('ok', true)
-  }, 20_000)
+      console.log({ wasm, zkey });
+      await expect(fetch(wasm)).resolves.toHaveProperty("ok", true);
+      await expect(fetch(zkey)).resolves.toHaveProperty("ok", true);
+    }, 20_000);
 
-  it('should throw if the project is not supported', async () => {
-    await expect(
-      getSnarkArtifactUrls('project' as Project, {
-        parameters: ['2'],
-        version: 'latest',
-      }),
-    ).rejects.toThrow("Project 'project' is not supported")
-  })
+    it("should throw if the project is not supported", async () => {
+      await expect(
+        maybeGetSnarkArtifactsBrowser("project" as Project, {
+          parameters: ["2"],
+          version: "latest",
+        })
+      ).rejects.toThrow("Project 'project' is not supported");
+    });
 
-  it('should throw if the version is not available', async () => {
-    await expect(
-      getSnarkArtifactUrls(Project.POSEIDON, {
-        parameters: ['2'],
-        version: '0.1.0-beta',
-      }),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Version '0.1.0-beta' is not available for project 'poseidon'"`,
-    )
-  })
-})
+    it("should throw if the version is not available", async () => {
+      await expect(
+        maybeGetSnarkArtifactsBrowser(Project.POSEIDON, {
+          parameters: ["2"],
+          version: "0.1.0-beta",
+        })
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Version '0.1.0-beta' is not available for project 'poseidon'"`
+      );
+    });
 
-describe('MaybeGetSnarkArtifacts', () => {
-  let fetchSpy: jest.SpyInstance
-  let mkdirSpy: jest.SpyInstance
-  let createWriteStreamSpy: jest.SpyInstance
-  let existsSyncSpy: jest.SpyInstance
+    it("Should return artifact file paths with parameters", async () => {
+      const { wasm, zkey } = await maybeGetSnarkArtifactsBrowser(
+        Project.POSEIDON,
+        {
+          parameters: ["2"],
+        }
+      );
 
-  beforeEach(() => {
-    // @ts-expect-error non exhaustive mock of fetch
-    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
-      json: async () => ({ versions: { [version]: {} } }),
-    })
-    createWriteStreamSpy = jest.spyOn(fs, 'createWriteStream')
-    existsSyncSpy = jest.spyOn(fs, 'existsSync')
-    mkdirSpy = jest.spyOn(fsPromises, 'mkdir')
-    mkdirSpy.mockResolvedValue(undefined)
-  })
+      expect(wasm).toMatchInlineSnapshot(
+        `"https://snark-artifacts.pse.dev/poseidon/latest/poseidon-2.wasm"`
+      );
+      expect(zkey).toMatchInlineSnapshot(
+        `"https://snark-artifacts.pse.dev/poseidon/latest/poseidon-2.zkey"`
+      );
+    });
 
-  afterEach(() => {
-    jest.restoreAllMocks()
-  })
+    it("Should return artifact files paths without parameters", async () => {
+      const { wasm, zkey } = await maybeGetSnarkArtifactsBrowser(
+        Project.SEMAPHORE
+      );
 
-  it('Should throw an error if the project is not supported', async () => {
-    await expect(
-      maybeGetSnarkArtifacts('project' as Project, {
-        parameters: ['2'],
-        version: 'latest',
-      }),
-    ).rejects.toThrow("Project 'project' is not supported")
+      expect(wasm).toMatchInlineSnapshot(
+        `"https://snark-artifacts.pse.dev/semaphore/latest/semaphore.wasm"`
+      );
+      expect(zkey).toMatchInlineSnapshot(
+        `"https://snark-artifacts.pse.dev/semaphore/latest/semaphore.zkey"`
+      );
+    });
+  });
 
-    await expect(
-      maybeGetSnarkArtifactsBrowser('project' as Project),
-    ).rejects.toThrow("Project 'project' is not supported")
-  })
+  describe("node", () => {
+    let fetchSpy: jest.SpyInstance;
+    let mkdirSpy: jest.SpyInstance;
+    let createWriteStreamSpy: jest.SpyInstance;
+    let existsSyncSpy: jest.SpyInstance;
 
-  it('Should throw on fetch errors', async () => {
-    existsSyncSpy.mockReturnValue(false)
-    fetchSpy.mockResolvedValueOnce({
-      ok: false,
-      statusText: 'TEST',
-      url: 'https://test.com',
-    })
+    beforeEach(() => {
+      // @ts-expect-error non exhaustive mock of fetch
+      fetchSpy = jest.spyOn(global, "fetch").mockResolvedValueOnce({
+        json: async () => ({ versions: { [version]: {} } }),
+      });
+      createWriteStreamSpy = jest.spyOn(fs, "createWriteStream");
+      existsSyncSpy = jest.spyOn(fs, "existsSync");
+      mkdirSpy = jest.spyOn(fsPromises, "mkdir");
+      mkdirSpy.mockResolvedValue(undefined);
+    });
 
-    await expect(
-      maybeGetSnarkArtifacts(Project.POSEIDON, {
-        parameters: ['2'],
-        version: 'latest',
-      }),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Failed to fetch https://test.com: TEST"`,
-    )
-  })
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
 
-  it('Should throw if missing body', async () => {
-    existsSyncSpy.mockReturnValue(false)
-    fetchSpy.mockResolvedValueOnce({
-      ok: true,
-      statusText: 'OK',
-    })
+    it("Should throw an error if the project is not supported", async () => {
+      await expect(
+        maybeGetSnarkArtifacts("project" as Project, {
+          parameters: ["2"],
+          version: "latest",
+        })
+      ).rejects.toThrow("Project 'project' is not supported");
 
-    await expect(
-      maybeGetSnarkArtifacts(Project.POSEIDON, {
-        parameters: ['2'],
-      }),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(
-      `"Failed to get response body"`,
-    )
-  })
+      await expect(
+        maybeGetSnarkArtifactsBrowser("project" as Project)
+      ).rejects.toThrow("Project 'project' is not supported");
+    });
 
-  it('Should throw on stream error', async () => {
-    existsSyncSpy.mockReturnValue(false)
-    const mockResponseStream = {
-      body: {
-        getReader: jest.fn(() => ({
-          read: jest.fn().mockRejectedValueOnce(new Error('TEST STREAM ERROR')),
-        })),
-      },
-      ok: true,
-      statusText: 'OK',
-    }
-    fetchSpy.mockResolvedValue(mockResponseStream)
-    createWriteStreamSpy.mockReturnValue({
-      close: jest.fn(),
-      end: jest.fn(),
-      write: jest.fn(),
-    })
+    it("Should throw on fetch errors", async () => {
+      existsSyncSpy.mockReturnValue(false);
+      fetchSpy.mockResolvedValueOnce({
+        ok: false,
+        statusText: "TEST",
+        url: "https://test.com",
+      });
 
-    await expect(
-      maybeGetSnarkArtifacts(Project.POSEIDON, {
-        parameters: ['2'],
-      }),
-    ).rejects.toThrowErrorMatchingInlineSnapshot(`"TEST STREAM ERROR"`)
-  })
+      await expect(
+        maybeGetSnarkArtifacts(Project.POSEIDON, {
+          parameters: ["2"],
+          version: "latest",
+        })
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Failed to fetch https://snark-artifacts.pse.dev/poseidon/latest/poseidon-2.wasm: TEST"`
+      );
+    });
 
-  it("Should download files only if don't exist yet", async () => {
-    existsSyncSpy.mockReturnValue(true)
+    it("Should throw if missing body", async () => {
+      existsSyncSpy.mockReturnValue(false);
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        statusText: "OK",
+      });
 
-    await maybeGetSnarkArtifacts(Project.POSEIDON, { parameters: ['2'] })
+      await expect(
+        maybeGetSnarkArtifacts(Project.POSEIDON, {
+          parameters: ["2"],
+        })
+      ).rejects.toThrowErrorMatchingInlineSnapshot(
+        `"Failed to get response body"`
+      );
+    });
 
-    expect(global.fetch).toHaveBeenCalledTimes(1)
-    expect(global.fetch).toHaveBeenLastCalledWith('https://registry.npmjs.org/@zk-kit/poseidon-artifacts')
-  })
+    it("Should throw on stream error", async () => {
+      existsSyncSpy.mockReturnValue(false);
+      const mockResponseStream = {
+        body: {
+          getReader: jest.fn(() => ({
+            read: jest
+              .fn()
+              .mockRejectedValueOnce(new Error("TEST STREAM ERROR")),
+          })),
+        },
+        ok: true,
+        statusText: "OK",
+      };
+      fetchSpy.mockResolvedValue(mockResponseStream);
+      createWriteStreamSpy.mockReturnValue({
+        close: jest.fn(),
+        end: jest.fn(),
+        write: jest.fn(),
+      });
 
-  it('Should return artifact file paths in node environment', async () => {
-    mkdirSpy.mockRestore()
-    existsSyncSpy.mockReturnValue(false)
+      await expect(
+        maybeGetSnarkArtifacts(Project.POSEIDON, {
+          parameters: ["2"],
+        })
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"TEST STREAM ERROR"`);
+    });
 
-    const { wasm, zkey } = await maybeGetSnarkArtifacts(Project.POSEIDON, {
-      parameters: ['2'],
-    })
+    it("Should download files only if don't exist yet", async () => {
+      existsSyncSpy.mockReturnValue(true);
 
-    expect(wasm).toMatchInlineSnapshot(
-      `"/tmp/@zk-kit/poseidon-artifacts@latest/poseidon-2.wasm"`,
-    )
-    expect(zkey).toMatchInlineSnapshot(
-      `"/tmp/@zk-kit/poseidon-artifacts@latest/poseidon-2.zkey"`,
-    )
+      await maybeGetSnarkArtifacts(Project.POSEIDON, { parameters: ["2"] });
 
-    expect(fetchSpy).toHaveBeenCalledTimes(3)
-    expect(fetchSpy).toHaveBeenNthCalledWith(1, 'https://registry.npmjs.org/@zk-kit/poseidon-artifacts')
-    expect(fetchSpy).toHaveBeenNthCalledWith(2, 'https://unpkg.com/@zk-kit/poseidon-artifacts@latest/poseidon-2.wasm')
-    expect(fetchSpy).toHaveBeenNthCalledWith(3, 'https://unpkg.com/@zk-kit/poseidon-artifacts@latest/poseidon-2.zkey')
-  }, 25_000)
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        "https://registry.npmjs.org/@zk-kit/poseidon-artifacts"
+      );
+    });
 
-  it('Should return artifact file paths with parameters in browser environment', async () => {
-    const { wasm, zkey } = await maybeGetSnarkArtifactsBrowser(
-      Project.POSEIDON,
-      {
-        parameters: ['2'],
-      },
-    )
+    it("Should return artifact file paths in node environment", async () => {
+      mkdirSpy.mockRestore();
+      existsSyncSpy.mockReturnValue(false);
 
-    expect(wasm).toMatchInlineSnapshot(
-      `"https://unpkg.com/@zk-kit/poseidon-artifacts@latest/poseidon-2.wasm"`,
-    )
-    expect(zkey).toMatchInlineSnapshot(
-      `"https://unpkg.com/@zk-kit/poseidon-artifacts@latest/poseidon-2.zkey"`,
-    )
-  })
+      const { wasm, zkey } = await maybeGetSnarkArtifacts(Project.POSEIDON, {
+        parameters: ["2"],
+      });
 
-  it('Should return artifact files paths without parameters in browser environment', async () => {
-    const { wasm, zkey } = await maybeGetSnarkArtifactsBrowser(
-      Project.SEMAPHORE,
-    )
+      expect(wasm).toMatchInlineSnapshot(
+        `"/tmp/snark-artifacts/poseidon/latest/poseidon-2.wasm"`
+      );
+      expect(zkey).toMatchInlineSnapshot(
+        `"/tmp/snark-artifacts/poseidon/latest/poseidon-2.zkey"`
+      );
 
-    expect(wasm).toMatchInlineSnapshot(
-      `"https://unpkg.com/@zk-kit/semaphore-artifacts@latest/semaphore.wasm"`,
-    )
-    expect(zkey).toMatchInlineSnapshot(
-      `"https://unpkg.com/@zk-kit/semaphore-artifacts@latest/semaphore.zkey"`,
-    )
-  })
-})
+      expect(fetchSpy).toHaveBeenCalledTimes(3);
+      expect(fetchSpy).toHaveBeenNthCalledWith(
+        1,
+        "https://registry.npmjs.org/@zk-kit/poseidon-artifacts"
+      );
+      expect(fetchSpy).toHaveBeenNthCalledWith(
+        2,
+        "https://snark-artifacts.pse.dev/poseidon/latest/poseidon-2.wasm"
+      );
+      expect(fetchSpy).toHaveBeenNthCalledWith(
+        3,
+        "https://snark-artifacts.pse.dev/poseidon/latest/poseidon-2.zkey"
+      );
+    }, 25_000);
+  });
+});

--- a/packages/artifacts/test/download.test.ts
+++ b/packages/artifacts/test/download.test.ts
@@ -26,7 +26,6 @@ describe('maybeGetSnarkArtifacts', () => {
         },
       )
 
-      console.log({ wasm, zkey })
       await expect(fetch(wasm)).resolves.toHaveProperty('ok', true)
       await expect(fetch(zkey)).resolves.toHaveProperty('ok', true)
     }, 20_000)

--- a/packages/artifacts/test/download.test.ts
+++ b/packages/artifacts/test/download.test.ts
@@ -1,220 +1,220 @@
-import fs from "node:fs";
-import fsPromises from "node:fs/promises";
-import maybeGetSnarkArtifactsBrowser from "../src/download/index.browser";
-import maybeGetSnarkArtifacts from "../src/download/index.node";
-import { getAvailableVersions } from "../src/download/urls";
-import { Project } from "../src/projects";
+import fs from 'node:fs'
+import fsPromises from 'node:fs/promises'
+import maybeGetSnarkArtifactsBrowser from '../src/download/index.browser'
+import maybeGetSnarkArtifacts from '../src/download/index.node'
+import { getAvailableVersions } from '../src/download/urls'
+import { Project } from '../src/projects'
 
-const version = "1.0.0-beta.1";
+const version = '1.0.0-beta.1'
 
-describe("getAvailableVersions", () => {
-  it("Should return available versions", async () => {
-    const versions = await getAvailableVersions(Project.POSEIDON);
+describe('getAvailableVersions', () => {
+  it('Should return available versions', async () => {
+    const versions = await getAvailableVersions(Project.POSEIDON)
 
-    expect(versions).toContain(version);
-  }, 20_000);
-});
+    expect(versions).toContain(version)
+  }, 20_000)
+})
 
-describe("maybeGetSnarkArtifacts", () => {
-  describe("browser", () => {
-    it("Should return valid urls", async () => {
+describe('maybeGetSnarkArtifacts', () => {
+  describe('browser', () => {
+    it('Should return valid urls', async () => {
       const { wasm, zkey } = await maybeGetSnarkArtifactsBrowser(
         Project.POSEIDON,
         {
-          parameters: ["2"],
+          parameters: ['2'],
           version,
-        }
-      );
+        },
+      )
 
-      console.log({ wasm, zkey });
-      await expect(fetch(wasm)).resolves.toHaveProperty("ok", true);
-      await expect(fetch(zkey)).resolves.toHaveProperty("ok", true);
-    }, 20_000);
+      console.log({ wasm, zkey })
+      await expect(fetch(wasm)).resolves.toHaveProperty('ok', true)
+      await expect(fetch(zkey)).resolves.toHaveProperty('ok', true)
+    }, 20_000)
 
-    it("should throw if the project is not supported", async () => {
+    it('should throw if the project is not supported', async () => {
       await expect(
-        maybeGetSnarkArtifactsBrowser("project" as Project, {
-          parameters: ["2"],
-          version: "latest",
-        })
-      ).rejects.toThrow("Project 'project' is not supported");
-    });
+        maybeGetSnarkArtifactsBrowser('project' as Project, {
+          parameters: ['2'],
+          version: 'latest',
+        }),
+      ).rejects.toThrow("Project 'project' is not supported")
+    })
 
-    it("should throw if the version is not available", async () => {
+    it('should throw if the version is not available', async () => {
       await expect(
         maybeGetSnarkArtifactsBrowser(Project.POSEIDON, {
-          parameters: ["2"],
-          version: "0.1.0-beta",
-        })
+          parameters: ['2'],
+          version: '0.1.0-beta',
+        }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Version '0.1.0-beta' is not available for project 'poseidon'"`
-      );
-    });
+        `"Version '0.1.0-beta' is not available for project 'poseidon'"`,
+      )
+    })
 
-    it("Should return artifact file paths with parameters", async () => {
+    it('Should return artifact file paths with parameters', async () => {
       const { wasm, zkey } = await maybeGetSnarkArtifactsBrowser(
         Project.POSEIDON,
         {
-          parameters: ["2"],
-        }
-      );
+          parameters: ['2'],
+        },
+      )
 
       expect(wasm).toMatchInlineSnapshot(
-        `"https://snark-artifacts.pse.dev/poseidon/latest/poseidon-2.wasm"`
-      );
+        `"https://snark-artifacts.pse.dev/poseidon/latest/poseidon-2.wasm"`,
+      )
       expect(zkey).toMatchInlineSnapshot(
-        `"https://snark-artifacts.pse.dev/poseidon/latest/poseidon-2.zkey"`
-      );
-    });
+        `"https://snark-artifacts.pse.dev/poseidon/latest/poseidon-2.zkey"`,
+      )
+    })
 
-    it("Should return artifact files paths without parameters", async () => {
+    it('Should return artifact files paths without parameters', async () => {
       const { wasm, zkey } = await maybeGetSnarkArtifactsBrowser(
-        Project.SEMAPHORE
-      );
+        Project.SEMAPHORE,
+      )
 
       expect(wasm).toMatchInlineSnapshot(
-        `"https://snark-artifacts.pse.dev/semaphore/latest/semaphore.wasm"`
-      );
+        `"https://snark-artifacts.pse.dev/semaphore/latest/semaphore.wasm"`,
+      )
       expect(zkey).toMatchInlineSnapshot(
-        `"https://snark-artifacts.pse.dev/semaphore/latest/semaphore.zkey"`
-      );
-    });
-  });
+        `"https://snark-artifacts.pse.dev/semaphore/latest/semaphore.zkey"`,
+      )
+    })
+  })
 
-  describe("node", () => {
-    let fetchSpy: jest.SpyInstance;
-    let mkdirSpy: jest.SpyInstance;
-    let createWriteStreamSpy: jest.SpyInstance;
-    let existsSyncSpy: jest.SpyInstance;
+  describe('node', () => {
+    let fetchSpy: jest.SpyInstance
+    let mkdirSpy: jest.SpyInstance
+    let createWriteStreamSpy: jest.SpyInstance
+    let existsSyncSpy: jest.SpyInstance
 
     beforeEach(() => {
       // @ts-expect-error non exhaustive mock of fetch
-      fetchSpy = jest.spyOn(global, "fetch").mockResolvedValueOnce({
+      fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValueOnce({
         json: async () => ({ versions: { [version]: {} } }),
-      });
-      createWriteStreamSpy = jest.spyOn(fs, "createWriteStream");
-      existsSyncSpy = jest.spyOn(fs, "existsSync");
-      mkdirSpy = jest.spyOn(fsPromises, "mkdir");
-      mkdirSpy.mockResolvedValue(undefined);
-    });
+      })
+      createWriteStreamSpy = jest.spyOn(fs, 'createWriteStream')
+      existsSyncSpy = jest.spyOn(fs, 'existsSync')
+      mkdirSpy = jest.spyOn(fsPromises, 'mkdir')
+      mkdirSpy.mockResolvedValue(undefined)
+    })
 
     afterEach(() => {
-      jest.restoreAllMocks();
-    });
+      jest.restoreAllMocks()
+    })
 
-    it("Should throw an error if the project is not supported", async () => {
+    it('Should throw an error if the project is not supported', async () => {
       await expect(
-        maybeGetSnarkArtifacts("project" as Project, {
-          parameters: ["2"],
-          version: "latest",
-        })
-      ).rejects.toThrow("Project 'project' is not supported");
+        maybeGetSnarkArtifacts('project' as Project, {
+          parameters: ['2'],
+          version: 'latest',
+        }),
+      ).rejects.toThrow("Project 'project' is not supported")
 
       await expect(
-        maybeGetSnarkArtifactsBrowser("project" as Project)
-      ).rejects.toThrow("Project 'project' is not supported");
-    });
+        maybeGetSnarkArtifactsBrowser('project' as Project),
+      ).rejects.toThrow("Project 'project' is not supported")
+    })
 
-    it("Should throw on fetch errors", async () => {
-      existsSyncSpy.mockReturnValue(false);
+    it('Should throw on fetch errors', async () => {
+      existsSyncSpy.mockReturnValue(false)
       fetchSpy.mockResolvedValueOnce({
         ok: false,
-        statusText: "TEST",
-        url: "https://test.com",
-      });
+        statusText: 'TEST',
+        url: 'https://test.com',
+      })
 
       await expect(
         maybeGetSnarkArtifacts(Project.POSEIDON, {
-          parameters: ["2"],
-          version: "latest",
-        })
+          parameters: ['2'],
+          version: 'latest',
+        }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Failed to fetch https://snark-artifacts.pse.dev/poseidon/latest/poseidon-2.wasm: TEST"`
-      );
-    });
+        `"Failed to fetch https://snark-artifacts.pse.dev/poseidon/latest/poseidon-2.wasm: TEST"`,
+      )
+    })
 
-    it("Should throw if missing body", async () => {
-      existsSyncSpy.mockReturnValue(false);
+    it('Should throw if missing body', async () => {
+      existsSyncSpy.mockReturnValue(false)
       fetchSpy.mockResolvedValueOnce({
         ok: true,
-        statusText: "OK",
-      });
+        statusText: 'OK',
+      })
 
       await expect(
         maybeGetSnarkArtifacts(Project.POSEIDON, {
-          parameters: ["2"],
-        })
+          parameters: ['2'],
+        }),
       ).rejects.toThrowErrorMatchingInlineSnapshot(
-        `"Failed to get response body"`
-      );
-    });
+        `"Failed to get response body"`,
+      )
+    })
 
-    it("Should throw on stream error", async () => {
-      existsSyncSpy.mockReturnValue(false);
+    it('Should throw on stream error', async () => {
+      existsSyncSpy.mockReturnValue(false)
       const mockResponseStream = {
         body: {
           getReader: jest.fn(() => ({
             read: jest
               .fn()
-              .mockRejectedValueOnce(new Error("TEST STREAM ERROR")),
+              .mockRejectedValueOnce(new Error('TEST STREAM ERROR')),
           })),
         },
         ok: true,
-        statusText: "OK",
-      };
-      fetchSpy.mockResolvedValue(mockResponseStream);
+        statusText: 'OK',
+      }
+      fetchSpy.mockResolvedValue(mockResponseStream)
       createWriteStreamSpy.mockReturnValue({
         close: jest.fn(),
         end: jest.fn(),
         write: jest.fn(),
-      });
+      })
 
       await expect(
         maybeGetSnarkArtifacts(Project.POSEIDON, {
-          parameters: ["2"],
-        })
-      ).rejects.toThrowErrorMatchingInlineSnapshot(`"TEST STREAM ERROR"`);
-    });
+          parameters: ['2'],
+        }),
+      ).rejects.toThrowErrorMatchingInlineSnapshot(`"TEST STREAM ERROR"`)
+    })
 
     it("Should download files only if don't exist yet", async () => {
-      existsSyncSpy.mockReturnValue(true);
+      existsSyncSpy.mockReturnValue(true)
 
-      await maybeGetSnarkArtifacts(Project.POSEIDON, { parameters: ["2"] });
+      await maybeGetSnarkArtifacts(Project.POSEIDON, { parameters: ['2'] })
 
-      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(global.fetch).toHaveBeenCalledTimes(1)
       expect(global.fetch).toHaveBeenLastCalledWith(
-        "https://registry.npmjs.org/@zk-kit/poseidon-artifacts"
-      );
-    });
+        'https://registry.npmjs.org/@zk-kit/poseidon-artifacts',
+      )
+    })
 
-    it("Should return artifact file paths in node environment", async () => {
-      mkdirSpy.mockRestore();
-      existsSyncSpy.mockReturnValue(false);
+    it('Should return artifact file paths in node environment', async () => {
+      mkdirSpy.mockRestore()
+      existsSyncSpy.mockReturnValue(false)
 
       const { wasm, zkey } = await maybeGetSnarkArtifacts(Project.POSEIDON, {
-        parameters: ["2"],
-      });
+        parameters: ['2'],
+      })
 
       expect(wasm).toMatchInlineSnapshot(
-        `"/tmp/snark-artifacts/poseidon/latest/poseidon-2.wasm"`
-      );
+        `"/tmp/snark-artifacts/poseidon/latest/poseidon-2.wasm"`,
+      )
       expect(zkey).toMatchInlineSnapshot(
-        `"/tmp/snark-artifacts/poseidon/latest/poseidon-2.zkey"`
-      );
+        `"/tmp/snark-artifacts/poseidon/latest/poseidon-2.zkey"`,
+      )
 
-      expect(fetchSpy).toHaveBeenCalledTimes(3);
+      expect(fetchSpy).toHaveBeenCalledTimes(3)
       expect(fetchSpy).toHaveBeenNthCalledWith(
         1,
-        "https://registry.npmjs.org/@zk-kit/poseidon-artifacts"
-      );
+        'https://registry.npmjs.org/@zk-kit/poseidon-artifacts',
+      )
       expect(fetchSpy).toHaveBeenNthCalledWith(
         2,
-        "https://snark-artifacts.pse.dev/poseidon/latest/poseidon-2.wasm"
-      );
+        'https://snark-artifacts.pse.dev/poseidon/latest/poseidon-2.wasm',
+      )
       expect(fetchSpy).toHaveBeenNthCalledWith(
         3,
-        "https://snark-artifacts.pse.dev/poseidon/latest/poseidon-2.zkey"
-      );
-    }, 25_000);
-  });
-});
+        'https://snark-artifacts.pse.dev/poseidon/latest/poseidon-2.zkey',
+      )
+    }, 25_000)
+  })
+})

--- a/packages/cli/test/integration.test.ts
+++ b/packages/cli/test/integration.test.ts
@@ -82,6 +82,7 @@ Commands:
           1.0.0-beta
         poseidon
           1.0.0
+          1.0.0-beta.1
         semaphore
           1.0.0
           4.0.0-beta.9


### PR DESCRIPTION
- use https://snark-artifacts.pse.dev (S3 bucket + cloudfront) as single source to download artifacts
- remove all logic about fetch retry mechanism
  This was a client side fix for a problem that is now solved with a new backend solution
  
  Closes #94 
