### PR TITLE
feat(artifacts): do not check if version exists prior downloading

### DIFF
--- a/.changeset/moody-cheetahs-knock.md
+++ b/.changeset/moody-cheetahs-knock.md
@@ -1,0 +1,5 @@
+---
+"@zk-kit/artifacts": minor
+---
+
+Do not check available versions prior to downloading artifacts

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,7 +6,7 @@ const projects = ['artifacts', 'cli'].map((name) => `packages/${name}/test`)
 const config: JestConfigWithTsJest = {
   preset: 'ts-jest',
   collectCoverage: true,
-  collectCoverageFrom: ['src/**/*.ts', '!src/index.ts'],
+  collectCoverageFrom: ['src/**/*.ts', '!src/index*.ts'],
   coverageDirectory: join(__dirname, '..', 'coverage'),
   coverageThreshold: {
     global: { branches: 40, functions: 60, lines: 80, statements: 80 },

--- a/packages/artifacts/src/download/index.browser.ts
+++ b/packages/artifacts/src/download/index.browser.ts
@@ -7,14 +7,13 @@ export default async function maybeGetSnarkArtifacts(
   options: {
     parameters?: (bigint | number | string)[]
     version?: Version
-    cdnUrl?: string
   } = {},
 ): Promise<SnarkArtifacts> {
   if (!projects.includes(project))
     throw new Error(`Project '${project}' is not supported`)
 
   options.version ??= 'latest'
-  const url = await getBaseUrl(project, options.version)
+  const url = getBaseUrl(project, options.version)
   const parameters = options.parameters
     ? `-${options.parameters.join('-')}`
     : ''

--- a/packages/artifacts/src/download/urls.ts
+++ b/packages/artifacts/src/download/urls.ts
@@ -3,19 +3,4 @@ import type { Version } from './types'
 
 const BASE_URL = 'https://snark-artifacts.pse.dev'
 
-export async function getAvailableVersions(project: Project) {
-  const res = await fetch(`https://registry.npmjs.org/@zk-kit/${project}-artifacts`)
-  const { versions } = await res.json()
-  return Object.keys(versions)
-}
-
-async function isVersionAvailableOrThrow(project: Project, version: Version) {
-  const availableVersions = await getAvailableVersions(project)
-  if (version !== 'latest' && !availableVersions.includes(version))
-    throw new Error(`Version '${version}' is not available for project '${project}'`)
-}
-
-export async function getBaseUrl(project: Project, version: Version): Promise<string> {
-  await isVersionAvailableOrThrow(project, version)
-  return `${BASE_URL}/${project}/${version}/${project}`
-}
+export const getBaseUrl = (project: Project, version: Version) => `${BASE_URL}/${project}/${version}/${project}`

--- a/packages/artifacts/src/index.shared.ts
+++ b/packages/artifacts/src/index.shared.ts
@@ -1,3 +1,2 @@
 export * from './download/types'
-export { getAvailableVersions } from './download/urls'
 export * from './projects'

--- a/packages/cli/test/integration.test.ts
+++ b/packages/cli/test/integration.test.ts
@@ -58,7 +58,7 @@ Commands:
           /tmp/@zk-kit/poseidon-artifacts@latest/poseidon-2.zkey",
         ]
       `)
-    }, 10_000)
+    }, 20_000)
   })
 
   describe('generate', () => {


### PR DESCRIPTION
||before|after|
|---|---|---|
||check if the requested version is available|do not check if the available version is available|
|pro|friendlier dx, explicit errors|better perf|
|con|degraded perf, making an extra request|request will simply fail with a 403 at runtime without further info|

Closes #102

This PR makes the following trade off: prefer better perf over better error handling.

## Notes
We can't use just a generic error upon trying to download the file because the browser version doesn't download anything but just returns url strings.
As an alternative solution, I tried using `HEAD` request (download only headers but no body) as a liveness check, but it appeared to be (strangely) slower than fetching a json from `registry.npmjs.org`.
So in the end I don't check anything.
Besides before we were checking the versions but not the parameters (we can't really prevent the user from using a wrong combination of parameters...)