### PR TITLE
feat(cli): generate batch of artifacts

### DIFF
--- a/.biome.jsonc
+++ b/.biome.jsonc
@@ -21,7 +21,7 @@
       "linter": { "rules": { "style": { "noParameterAssign": "off" } } },
     },
     {
-      "include": ["apps/web/src/main.tsx"],
+      "include": ["apps/web/src/main.tsx", "packages/cli/src/commands/generate/action.ts"],
       "linter": { "rules": { "style": { "noNonNullAssertion": "off" } } },
     },
   ],

--- a/.biome.jsonc
+++ b/.biome.jsonc
@@ -13,7 +13,7 @@
   },
   "overrides": [
     {
-      "include": ["packages/cli/src/spinner.ts"],
+      "include": ["packages/cli/src/spinner.ts", "packages/cli/src/commands/generate/action.ts"],
       "linter": { "rules": { "suspicious": { "noExplicitAny": "off" } } },
     },
     {

--- a/.changeset/orange-camels-listen.md
+++ b/.changeset/orange-camels-listen.md
@@ -1,0 +1,5 @@
+---
+"@zk-kit/artifacts-cli": minor
+---
+
+Generate batch of artifacts

--- a/.changeset/stupid-beers-beg.md
+++ b/.changeset/stupid-beers-beg.md
@@ -1,0 +1,5 @@
+---
+"@zk-kit/artifacts-cli": minor
+---
+
+Can override circuits parameters in generate command

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -9,7 +9,7 @@ const config: JestConfigWithTsJest = {
   collectCoverageFrom: ['src/**/*.ts', '!src/index*.ts'],
   coverageDirectory: join(__dirname, '..', 'coverage'),
   coverageThreshold: {
-    global: { branches: 40, functions: 60, lines: 80, statements: 80 },
+    global: { branches: 40, functions: 55, lines: 75, statements: 75 },
   },
   moduleDirectories: ['node_modules', '<rootDir>/node_modules', '<rootDir>/src'],
   moduleFileExtensions: ['js', 'ts'],

--- a/packages/cli/rollup.config.ts
+++ b/packages/cli/rollup.config.ts
@@ -24,7 +24,15 @@ const config: RollupOptions = {
   plugins: [
     typescript({ tsconfig: './tsconfig.build.json' }),
   ],
-  external: [...Object.keys(pkg.dependencies), 'node:console', 'node:fs', 'node:os', 'node:path', 'node:process'],
+  external: [
+    ...Object.keys(pkg.dependencies),
+    'node:console',
+    'node:fs',
+    'node:os',
+    'node:path',
+    'node:process',
+    'node:stream',
+  ],
 }
 
 export default config

--- a/packages/cli/rollup.config.ts
+++ b/packages/cli/rollup.config.ts
@@ -24,7 +24,7 @@ const config: RollupOptions = {
   plugins: [
     typescript({ tsconfig: './tsconfig.build.json' }),
   ],
-  external: [...Object.keys(pkg.dependencies), 'node:console', 'node:fs', 'node:path', 'node:process'],
+  external: [...Object.keys(pkg.dependencies), 'node:console', 'node:fs', 'node:os', 'node:path', 'node:process'],
 }
 
 export default config

--- a/packages/cli/src/commands/generate-batch/action.ts
+++ b/packages/cli/src/commands/generate-batch/action.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs'
+import { exit } from 'node:process'
+import { generateActionNoExit } from '../generate/action.ts'
+
+export default async function generateBatch(optionsPath: string, destination: string) {
+  const options = JSON.parse(readFileSync(optionsPath, 'utf8')) as Record<
+    string,
+    { circuit: string; paramsList: string[][] }
+  >
+  await Promise.all(
+    Object.entries(options).flatMap(([config, { circuit, paramsList }]) => {
+      paramsList.map(async (params) => {
+        await generateActionNoExit(circuit, params, { config, destination })
+      })
+    }),
+  )
+
+  exit(0)
+}

--- a/packages/cli/src/commands/generate-batch/action.ts
+++ b/packages/cli/src/commands/generate-batch/action.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { exit } from 'node:process'
+import { spinner } from '../../spinner.ts'
 import { generateActionNoExit } from '../generate/action.ts'
 
 export default async function generateBatch(optionsPath: string, destination: string) {
@@ -7,13 +8,13 @@ export default async function generateBatch(optionsPath: string, destination: st
     string,
     { circuit: string; paramsList: string[][] }
   >
-  await Promise.all(
-    Object.entries(options).flatMap(([config, { circuit, paramsList }]) => {
-      paramsList.map(async (params) => {
-        await generateActionNoExit(circuit, params, { config, destination })
-      })
-    }),
-  )
 
+  spinner.start()
+  for (const [config, { circuit, paramsList }] of Object.entries(options)) {
+    for (const params of paramsList)
+      await generateActionNoExit(circuit, params, { config, destination })
+  }
+
+  spinner.succeed(`All snark artifacts generated successfully in ${destination}`)
   exit(0)
 }

--- a/packages/cli/src/commands/generate-batch/index.ts
+++ b/packages/cli/src/commands/generate-batch/index.ts
@@ -1,0 +1,12 @@
+import { Command } from '@commander-js/extra-typings'
+import generateBatchAction from './action.ts'
+
+export const generateBatch = new Command('generate-batch').alias('gb').description(
+  'Generate snark artifacts for a list of circom circuits',
+)
+  .argument(
+    '<optionsPath>',
+    'Path to the options definition json file: { [circomkitJsonPath]: { circuit:string, params: string[][] }}',
+  )
+  .argument('<destination>', 'Destination directory for the generated artifacts')
+  .action(generateBatchAction)

--- a/packages/cli/src/commands/generate/action.ts
+++ b/packages/cli/src/commands/generate/action.ts
@@ -7,7 +7,7 @@ import { spinner } from '../../spinner.ts'
 import { validateJsonFileInput, validateOrThrow } from '../../validators.ts'
 import { getCircomkitConfigInput, getDestinationInput, selectCircuit } from './prompts.ts'
 
-export async function setup(params: string[] | undefined, config: string, dirBuild: string) {
+async function setup(params: string[] | undefined, config: string, dirBuild: string) {
   // parse circomkit.json
   let circomkitConfig = JSON.parse(readFileSync(config, 'utf8')) as CircomkitConfig
   chdir(dirname(config))

--- a/packages/cli/src/commands/generate/action.ts
+++ b/packages/cli/src/commands/generate/action.ts
@@ -1,22 +1,40 @@
-import { Circomkit, type CircomkitConfig } from 'circomkit'
-import { existsSync, readFileSync } from 'node:fs'
+import { Circomkit, type CircomkitConfig, type CircuitConfig } from 'circomkit'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { dirname } from 'node:path'
 import { chdir, cwd, exit } from 'node:process'
 import { spinner } from '../../spinner.ts'
 import { validateJsonFileInput, validateOrThrow } from '../../validators.ts'
 import { getCircomkitConfigInput, getDestinationInput, selectCircuit } from './prompts.ts'
 
-export async function setup(config: string, dirBuild: string) {
-  const circomkitConfig = JSON.parse(readFileSync(config, 'utf8')) as CircomkitConfig
+export async function setup(params: string[] | undefined, config: string, dirBuild: string) {
+  // parse circomkit.json
+  let circomkitConfig = JSON.parse(readFileSync(config, 'utf8')) as CircomkitConfig
   chdir(dirname(config))
-  const circuits = Object.keys(JSON.parse(readFileSync(circomkitConfig.circuits, 'utf8')))
-  const circuit = await selectCircuit(circuits)
-  const circomkit = new Circomkit({ ...JSON.parse(readFileSync(config, 'utf8')), dirBuild })
 
+  // parse circuits.json
+  const circuitsConfig = JSON.parse(readFileSync(circomkitConfig.circuits, 'utf8')) as Record<string, CircuitConfig>
+  const circuit = await selectCircuit(Object.keys(circuitsConfig))
+  let { circuits } = circomkitConfig
+
+  if (params !== undefined && params.length > 0) {
+    circuits = `${tmpdir}/${[circuit, ...params, 'circuits'].join('-')}.json`
+    dirBuild += `/${[circuit, ...params].join('-')}`
+    writeFileSync(
+      circuits,
+      JSON.stringify({ ...circuitsConfig, [circuit]: { ...circuitsConfig[circuit], params } }),
+      'utf8',
+    )
+  }
+
+  // override circomkit config options
+  circomkitConfig = { ...circomkitConfig, circuits, dirBuild }
+  const circomkit = new Circomkit(circomkitConfig)
   return circomkit.setup(circuit)
 }
 
 async function generateAction(
+  params: string[] | undefined,
   { config, destination }: { config?: string; destination?: string },
 ) {
   validateOrThrow(config, validateJsonFileInput)
@@ -24,7 +42,7 @@ async function generateAction(
 
   config ??= await getCircomkitConfigInput()
   const dirBuild = destination ?? await getDestinationInput(`${cwd()}/snark-artifacts`)
-  await setup(config, dirBuild)
+  await setup(params, config, dirBuild)
   spinner.succeed(`Snark artifacts generated successfully in ${dirBuild}`)
   exit(0)
 }

--- a/packages/cli/src/commands/generate/index.ts
+++ b/packages/cli/src/commands/generate/index.ts
@@ -8,5 +8,6 @@ export const generate = new Command('generate').alias('g').description(
   'Path to circomkit configuration file',
 )
   .option('-d, --destination <path>', 'Destination directory for the generated artifacts')
+  .argument('[circuit]', 'Circuit to generate snark artifacts for')
   .argument('[params...]', 'Circuit parameters override')
   .action(generateAction)

--- a/packages/cli/src/commands/generate/index.ts
+++ b/packages/cli/src/commands/generate/index.ts
@@ -8,4 +8,5 @@ export const generate = new Command('generate').alias('g').description(
   'Path to circomkit configuration file',
 )
   .option('-d, --destination <path>', 'Destination directory for the generated artifacts')
+  .argument('[params...]', 'Circuit parameters override')
   .action(generateAction)

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -1,5 +1,6 @@
 import { download } from './download/index.ts'
+import { generateBatch } from './generate-batch/index.ts'
 import { generate } from './generate/index.ts'
 import { list } from './list.ts'
 
-export default [download, generate, list]
+export default [download, generate, generateBatch, list]

--- a/packages/cli/test/integration.test.ts
+++ b/packages/cli/test/integration.test.ts
@@ -1,27 +1,26 @@
 // import { writeFileSync } from 'node:fs'
-import { rm } from "node:fs/promises";
-import { stdout } from "node:process";
-import { Cli } from "../src/cli";
+import { rm } from 'node:fs/promises'
+import { stdout } from 'node:process'
+import { Cli } from '../src/cli'
 
-describe("CLI", () => {
-  let cli: Cli;
-  const consoleSpy = jest.spyOn(console, "log");
-  const run = async (args: string[]) =>
-    cli.run(["node", "snarkli.js", ...args]);
+describe('CLI', () => {
+  let cli: Cli
+  const consoleSpy = jest.spyOn(console, 'log')
+  const run = async (args: string[]) => cli.run(['node', 'snarkli.js', ...args])
 
   beforeAll(() => {
     // avoid polluting stdout/sterr with command results' during tests
-    jest.spyOn(stdout, "write").mockImplementation(() => true);
-  });
+    jest.spyOn(stdout, 'write').mockImplementation(() => true)
+  })
   beforeEach(() => {
-    cli = new Cli();
-  });
+    cli = new Cli()
+  })
   afterEach(() => {
-    consoleSpy.mockClear();
+    consoleSpy.mockClear()
     // consoleSpy.mockRestore()
-  });
+  })
 
-  it("should display the help message", async () => {
+  it('should display the help message', async () => {
     cli.cli.exitOverride().configureOutput({
       writeOut(str) {
         expect(str).toMatchInlineSnapshot(`
@@ -37,44 +36,44 @@ Commands:
   list|l                                         List all projects and their available packages versions
   help [command]                                 display help for command
 "
-`);
+`)
       },
-    });
+    })
 
-    await expect(run(["--help"])).rejects.toMatchInlineSnapshot(
-      "[CommanderError: (outputHelp)]"
-    );
-  });
+    await expect(run(['--help'])).rejects.toMatchInlineSnapshot(
+      '[CommanderError: (outputHelp)]',
+    )
+  })
 
-  describe("download", () => {
-    it("should download artifacts for the specified project", async () => {
-      await run(["download", "poseidon", "-p", "2"]);
-      expect(consoleSpy).toHaveBeenCalledTimes(1);
+  describe('download', () => {
+    it('should download artifacts for the specified project', async () => {
+      await run(['download', 'poseidon', '-p', '2'])
+      expect(consoleSpy).toHaveBeenCalledTimes(1)
       expect(consoleSpy.mock.calls[0]).toMatchInlineSnapshot(`
         [
           "Artifacts downloaded at:
           /tmp/@zk-kit/poseidon-artifacts@latest/poseidon-2.wasm
           /tmp/@zk-kit/poseidon-artifacts@latest/poseidon-2.zkey",
         ]
-      `);
-    }, 30_000);
-  });
+      `)
+    }, 30_000)
+  })
 
-  describe("generate", () => {
-    const circomkitJson = "circomkit.json";
+  describe('generate', () => {
+    const circomkitJson = 'circomkit.json'
 
     afterAll(async () => {
       await rm(circomkitJson).catch(() => {
         /* swallow */
-      });
-    });
+      })
+    })
 
-    it.todo("should generate artifacts");
-  });
+    it.todo('should generate artifacts')
+  })
 
-  describe("list", () => {
-    it("should list all projects and the available versions", async () => {
-      await run(["list"]);
+  describe('list', () => {
+    it('should list all projects and the available versions', async () => {
+      await run(['list'])
       expect(consoleSpy.mock.calls[0]).toMatchInlineSnapshot(`
         [
           "semaphore-identity
@@ -89,7 +88,7 @@ Commands:
           4.0.0-beta.11
         ",
         ]
-      `);
-    });
-  });
-});
+      `)
+    })
+  })
+})

--- a/packages/cli/test/integration.test.ts
+++ b/packages/cli/test/integration.test.ts
@@ -1,81 +1,80 @@
 // import { writeFileSync } from 'node:fs'
-import { rm } from 'node:fs/promises'
-import { stdout } from 'node:process'
-import { Cli } from '../src/cli'
+import { rm } from "node:fs/promises";
+import { stdout } from "node:process";
+import { Cli } from "../src/cli";
 
-describe('CLI', () => {
-  let cli: Cli
-  const consoleSpy = jest.spyOn(console, 'log')
-  const run = async (args: string[]) => cli.run(['node', 'snarkli.js', ...args])
+describe("CLI", () => {
+  let cli: Cli;
+  const consoleSpy = jest.spyOn(console, "log");
+  const run = async (args: string[]) =>
+    cli.run(["node", "snarkli.js", ...args]);
 
   beforeAll(() => {
     // avoid polluting stdout/sterr with command results' during tests
-    jest.spyOn(stdout, 'write').mockImplementation(() => true)
-  })
+    jest.spyOn(stdout, "write").mockImplementation(() => true);
+  });
   beforeEach(() => {
-    cli = new Cli()
-  })
+    cli = new Cli();
+  });
   afterEach(() => {
-    consoleSpy.mockClear()
+    consoleSpy.mockClear();
     // consoleSpy.mockRestore()
-  })
+  });
 
-  it('should display the help message', async () => {
+  it("should display the help message", async () => {
     cli.cli.exitOverride().configureOutput({
       writeOut(str) {
         expect(str).toMatchInlineSnapshot(`
 "Usage: snarkli [options] [command]
 
 Options:
-  -h, --help                      display help for command
+  -h, --help                                     display help for command
 
 Commands:
-  download|d [options] [project]  Download all available artifacts for a given
-                                  project
-  generate|g [options]            Generate snark artifacts for a given source
-                                  circom circuit
-  list|l                          List all projects and their available
-                                  packages versions
-  help [command]                  display help for command
+  download|d [options] [project]                 Download all available artifacts for a given project
+  generate|g [options] [circuit] [params...]     Generate snark artifacts for a given source circom circuit
+  generate-batch|gb <optionsPath> <destination>  Generate snark artifacts for a list of circom circuits
+  list|l                                         List all projects and their available packages versions
+  help [command]                                 display help for command
 "
-`)
+`);
       },
-    })
+    });
 
-    await expect(run(['--help'])).rejects.toMatchInlineSnapshot(
-      '[CommanderError: (outputHelp)]',
-    )
-  })
+    await expect(run(["--help"])).rejects.toMatchInlineSnapshot(
+      "[CommanderError: (outputHelp)]"
+    );
+  });
 
-  describe('download', () => {
-    it('should download artifacts for the specified project', async () => {
-      await run(['download', 'poseidon', '-p', '2'])
-      expect(consoleSpy).toHaveBeenCalledTimes(1)
+  describe("download", () => {
+    it("should download artifacts for the specified project", async () => {
+      await run(["download", "poseidon", "-p", "2"]);
+      expect(consoleSpy).toHaveBeenCalledTimes(1);
       expect(consoleSpy.mock.calls[0]).toMatchInlineSnapshot(`
         [
           "Artifacts downloaded at:
           /tmp/@zk-kit/poseidon-artifacts@latest/poseidon-2.wasm
           /tmp/@zk-kit/poseidon-artifacts@latest/poseidon-2.zkey",
         ]
-      `)
-    }, 30_000)
-  })
+      `);
+    }, 30_000);
+  });
 
-  describe('generate', () => {
-    const circomkitJson = 'circomkit.json'
+  describe("generate", () => {
+    const circomkitJson = "circomkit.json";
 
     afterAll(async () => {
       await rm(circomkitJson).catch(() => {
         /* swallow */
-      })
-    })
+      });
+    });
 
-    it.todo('should generate artifacts')
-  })
+    it.todo("should generate artifacts");
+  });
 
-  describe('list', () => {
-    it('should list all projects and the available versions', async () => {
-      await run(['list'])
+  describe("list", () => {
+    it("should list all projects and the available versions", async () => {
+      await run(["list"]);
       expect(consoleSpy.mock.calls[0]).toMatchInlineSnapshot(`
         [
           "semaphore-identity
@@ -90,7 +89,7 @@ Commands:
           4.0.0-beta.11
         ",
         ]
-      `)
-    })
-  })
-})
+      `);
+    });
+  });
+});


### PR DESCRIPTION
Towards #35.

- can pass parameters to `generate` command to override the default found in the `circuits.json` config file
- implement a `generate-batch` command
  Works by looping over the content of a json file passed as argument
  
 ## Test plan
 - define an `options.json` file:
    <details>
    <summary>example</summary>
    
    ```json
    {
      "/home/sripwoud/code/zk-kit/zk-kit.circom/packages/poseidon-proof/circomkit.json": {
        "circuit": "poseidon-proof",
        "paramsList": [[1], [2]]
      },
      "/home/sripwoud/code/semaphore/semaphore/packages/circuits/circomkit.json": {
        "circuit": "semaphore",
        "paramsList": [[1], [2]]
      }
    }
    ```
    </details>

- run command: `cd packages/cli && pnpm build && pnpm start gb <pathToOptions.json> <destination>`


## Notes
This isn't perfect.
The error handling and logging can be improved