### PR TITLE
Update CloudFront functions to the latest package version

### DIFF
--- a/.github/scripts/update-cloudfront.sh
+++ b/.github/scripts/update-cloudfront.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e
+
+artifacts=$(ls packages/ | grep -v 'artifacts\|cli')
+
+cd packages
+
+for artifact in $artifacts; do
+  aws cloudfront get-function --name $artifact --stage LIVE output >/dev/null 2>&1
+
+  package_latest_version=$(jq -r '.version' "$artifact/package.json")
+  cloudfront_current_version=$(egrep 'request.uri =' output | awk -F"/" '{ print $6 }')
+
+  if [ $package_latest_version != $cloudfront_current_version ]; then
+    echo "Modifying $artifact function"
+    sed -i "s/$cloudfront_current_version/$package_latest_version/" output
+    echo "Updating $artifact function"
+    etag=$(aws cloudfront describe-function --name $artifact --query 'ETag' --output text)
+    aws cloudfront update-function --name $artifact --if-match $etag --function-config '{"Comment": "'"$artifact"'", "Runtime": "cloudfront-js-2.0"}' --function-code fileb://output >/dev/null 2>&1
+    echo "Publishing $artifact"
+    etag=$(aws cloudfront describe-function --name $artifact --query 'ETag' --output text)
+    aws cloudfront publish-function --name $artifact --if-match $etag >/dev/null 2>&1
+  else
+    echo "No changes applied for $artifact"
+  fi
+done
+
+exit 0

--- a/.github/workflows/upload-artifacts.yaml
+++ b/.github/workflows/upload-artifacts.yaml
@@ -49,3 +49,7 @@ jobs:
       - name: Upload artifacts to S3 bucket
         run: |
           .github/scripts/upload-artifacts.sh
+
+      - name: Update CloudFront
+        run: |
+          .github/scripts/update-cloudfront.sh


### PR DESCRIPTION
We 're using CloudFront functions to rewrite all URI requests from /latest/* to the latest package version uploaded in the S3 bucket.
F.x.:
```
/poseidon/latest/ -> /poseidon/1.0.0-beta.1/
```

With this PR, a new feature is introduced that automates the update of CloudFront functions to point to the new package versions upon release.

Changes:
- A new step was added to the workflow that triggers a script
- An aux script was created that compares the latest version in the CloudFront function against the deployed package version. If the versions differ, it updates and publishes the function that now includes the latest package version.

Closes #95