### PR TITLE
ci: fix update update-cloudfront.sh

### DIFF
--- a/.github/scripts/update-cloudfront.sh
+++ b/.github/scripts/update-cloudfront.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 set -e
 
-artifacts=$(ls packages/ | grep -v 'artifacts\|cli')
-
 cd packages
 
-for artifact in $artifacts; do
+for artifact in $(ls | grep -v 'artifacts\|cli'); do
   aws cloudfront get-function --name $artifact --stage LIVE output >/dev/null 2>&1
 
   package_latest_version=$(jq -r '.version' "$artifact/package.json")


### PR DESCRIPTION
I missed this when reviewing the PR:
if we store the result of `ls packages/ | grep -v 'artifacts\|cli'` before looping, the shell we split it line by line before looping, which breaks the loop.
I suggest sticking to [command subsitution, as in this case newlines are deleted](https://www.gnu.org/software/bash/manual/bash.html#Command-Substitution) and the for loop will work as intended
> Bash performs the expansion by executing command in a subshell environment and replacing the command substitution with the standard output of the command, with any trailing newlines deleted. Embedded newlines are not deleted, but they may be removed during word splitting 

![image](https://github.com/privacy-scaling-explorations/snark-artifacts/assets/38692952/5736058d-fd34-4df0-9886-441a06be8eff)

