### PR TITLE
ci: ignore error if `latest` git tag doesn't exist

### DIFF
--- a/scripts/bin/move-latest-tag.bash
+++ b/scripts/bin/move-latest-tag.bash
@@ -7,7 +7,7 @@ move_tag() {
   local commit_sha="$2"
   local tag="$package@latest"
 
-  git push -d origin "$tag"
+  git push -d origin "$tag" || true # ignore error if "latest" tag does not exist yet
   git tag "$tag" "$commit_sha"
   git push origin "$tag"
 }


### PR DESCRIPTION
Fix #129 
Fix `remote ref does not exist` [error](https://github.com/privacy-scaling-explorations/snark-artifacts/actions/runs/10042284804/job/27752377367#step:7:7) in `move-latest-tag.bash` script.

Suggested fix is to just ignore that error if the `latest` tag does not exist yet... and continue to create it the first time.

This will also fix the [error](https://github.com/privacy-scaling-explorations/snark-artifacts/actions/runs/10042284804/job/27752377367#step:7:7) seen in the `upload-artifacts` workflow:  
Indeed the `upload-artifacts` worklow "[waits for the `release` workflow to succeed](https://github.com/privacy-scaling-explorations/snark-artifacts/blob/6f83d0983bd97a646845c6e29dfbaee5e4055432/.github/workflows/upload-artifacts.yaml#L23)"... so if `release` fails, `ulpoad-artifacts` will fail too.
