### PR TITLE
fix `postinstall` script

### DIFF
--- a/scripts/bin/postinstall.bash
+++ b/scripts/bin/postinstall.bash
@@ -16,7 +16,9 @@ download() {
 }
 
 exit_if_shfmt_installed() {
-  command -v shfmt >/dev/null 2>&1 && exit 0
+  if command -v shfmt >/dev/null 2>&1; then
+    exit 0
+  fi
 }
 
 check_install() {


### PR DESCRIPTION
As I cloned this on a new machine, I also encountered a failing `postinstall` script.
Reason was that in [`exit_if_shmt_installed`](https://github.com/privacy-scaling-explorations/snark-artifacts/blob/c8f24fb8dfeee964943f7f44e97025260641f2cf/scripts/bin/postinstall.bash#L18), `command -v shfmt` actually returns 1 if `shfmt` is not installed, so the `set -e` flag will make the script early exit with 1 
