### PR TITLE
test(cli): check if vkeys match

### DIFF
--- a/scripts/bin/test-cli-generate.bash
+++ b/scripts/bin/test-cli-generate.bash
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -e
+
+main() {
+  original_dir=$(pwd)
+  zk_kit_repo=$(mktemp -d -t zk_kit-XXX)
+  circuit="poseidon-proof"
+  vkey_file="groth16_vkey.json"
+  dest_dir=$(mktemp -d -t snark-artifacts-poseidon-proof-XXX)
+
+  # setup
+  git clone https://github.com/privacy-scaling-explorations/zk-kit.circom.git "$zk_kit_repo"
+  cd "$zk_kit_repo"
+  yarn
+  cd "$original_dir"
+  pnpm i
+
+  # generate vkey in zk-kit.circom repo with circomkit
+  cd "$zk_kit_repo/packages/$circuit"
+  yarn run circomkit setup "$circuit"
+
+  # generate vkey in snark-artifacts repo with cli
+  cd "$original_dir/packages/artifacts"
+  pnpm start.cli generate -c "$zk_kit_repo/packages/$circuit/circomkit.json" -d "$dest_dir" "$circuit"
+
+  # matching?
+  diff "$zk_kit_repo/packages/$circuit/build/$circuit/$vkey_file" "$dest_dir/$circuit/$vkey_file"
+}
+
+main


### PR DESCRIPTION
```commandline
scripts/bin/test-cli-generate.bash
```

this 
- clones `zk-kit.circom`
- generates the vkey for the poseidon-proof circuit
  - with `circomkit`
  - with the snark-artifacts CLI (`generate` command)
- check if they match (`diff`)

Then don't match but I don't understand why 